### PR TITLE
No to_json for Strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mint_http (0.1.6)
+    mint_http (0.1.8)
       base64
       json
       net-http
@@ -11,16 +11,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.1.1)
-    ipaddr (1.2.5)
-    json (2.6.3)
+    base64 (0.2.0)
+    json (2.7.2)
     minitest (5.18.0)
-    net-http (0.3.2)
+    net-http (0.4.1)
       uri
-    openssl (2.2.3)
-      ipaddr
+    openssl (3.2.0)
     rake (13.0.6)
-    uri (0.12.2)
+    uri (0.13.0)
 
 PLATFORMS
   arm64-darwin-22
@@ -31,4 +29,4 @@ DEPENDENCIES
   rake (~> 13.0)
 
 BUNDLED WITH
-   2.2.33
+   2.3.16

--- a/lib/mint_http/request.rb
+++ b/lib/mint_http/request.rb
@@ -283,6 +283,10 @@ module MintHttp
           net_request.body = @body
         when :json
           net_request.body = @body.to_json if @body
+
+          if String === @body
+            net_request.body = @body
+          end
         when :form
           net_request.body = URI.encode_www_form(@body) if @body
         when :multipart

--- a/lib/mint_http/version.rb
+++ b/lib/mint_http/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MintHttp
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
Hey @ahoshaiyan 👋

The goal of this PR is to support sending the JSON body as a pure String without `to_json` ing it. It solves a use case when an external service requires you to:

- Calculate the digest of the body and attach it in the header
- Send the exact String that the digest was calculated for as the body

I faced this issue when integrating with Cybersource using their REST API which requires an "elaborate" HTTP authentication.

Please let me know what do you think.