### PR TITLE
Fix error on non-tcp sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.1.2] - 2025-05-27
+
+- Log local and remote addresses
+
 ## [1.0.1] - 2025-05-26
 
 - Add SSL min and max version support

--- a/lib/mint_http/request_logger.rb
+++ b/lib/mint_http/request_logger.rb
@@ -137,7 +137,7 @@ module MintHttp
       end
 
       socket = http.underlying_tcp_socket
-      if socket
+      if socket && socket.is_a?(TCPSocket)
         @local_address = socket.local_address
         @remote_address = socket.remote_address
       end

--- a/lib/mint_http/version.rb
+++ b/lib/mint_http/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MintHttp
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
Fixes:
```
     NoMethodError:
       undefined method `local_address' for an instance of StubSocket::StubIO
     # /Users/aa/.rvm/gems/ruby-3.3.6/gems/mint_http-1.1.1/lib/mint_http/request_logger.rb:141:in `log_connection_info'
```