### PR TITLE
Rescue Calculating Length of Empty Body Response

### DIFF
--- a/lib/mint_http/request_logger.rb
+++ b/lib/mint_http/request_logger.rb
@@ -110,7 +110,7 @@ module MintHttp
         buffer << <<~TXT
           <- Response: HTTP/#{@response.version} #{@response.status_code} #{@response.status_text}
           #{masked_headers(@response.headers, '<- ')}
-          <- Length: #{@response.body.bytesize} Body: #{masked_body(@response.body, @response.headers['content-type'])}
+          <- Length: #{@response.body&.bytesize || 0} Body: #{masked_body(@response.body, @response.headers['content-type'])}
         TXT
       end
 


### PR DESCRIPTION
Hello @ahoshaiyan 👋

This PR "rescues" an issue when the response body is empty. I encountered this issue with a DELETE request that returned a `204` status code with no body.

Please let me know what do you think.